### PR TITLE
Fixing starlette logout

### DIFF
--- a/src/keycloak/extensions/starlette.py
+++ b/src/keycloak/extensions/starlette.py
@@ -28,7 +28,6 @@ class Login(EndpointHandler):
 class Logout(EndpointHandler):
     async def get(self, request: Request) -> Response:
 
-        # request kc logout if we have the needed tokens
         if "tokens" in request.session:
             _tokens = request.session["tokens"]
             tokens = json.loads(_tokens)
@@ -60,7 +59,8 @@ class Callback(EndpointHandler):
 
         # starlette session do not have enough capacity to store the entire tokens
         # so we are saving only access token and refresh token required for performing logout properly
-        request.session["tokens"] = {"access_token" : tokens.access_token, "refresh_token" : tokens.refresh_token}
+        _tokens = {"access_token" : tokens.access_token, "refresh_token" : tokens.refresh_token}
+        request.session["tokens"] = json.dumps(_tokens)
 
         # retrieve user info
         access_token = tokens["access_token"]

--- a/src/keycloak/extensions/starlette.py
+++ b/src/keycloak/extensions/starlette.py
@@ -30,9 +30,9 @@ class Logout(EndpointHandler):
 
         # request kc logout if we have the needed tokens
         if "tokens" in request.session:
-            access_token = request.session["tokens"]["access_token"]
-            refresh_token = request.session["tokens"]["refresh_token"]
-            self.kc.logout(access_token, refresh_token)
+            _tokens = request.session["tokens"]
+            tokens = json.loads(_tokens)
+            self.kc.logout(tokens["access_token"], tokens["refresh_token"])
             del request.session["tokens"]
 
         if "user" in request.session:
@@ -60,10 +60,7 @@ class Callback(EndpointHandler):
 
         # starlette session do not have enough capacity to store the entire tokens
         # so we are saving only access token and refresh token required for performing logout properly
-        request.session["tokens"] = {
-            "access_token" : tokens.access_token,
-            "refresh_token" : tokens.refresh_token
-        }
+        request.session["tokens"] = {"access_token" : tokens.access_token, "refresh_token" : tokens.refresh_token}
 
         # retrieve user info
         access_token = tokens["access_token"]

--- a/src/keycloak/extensions/starlette.py
+++ b/src/keycloak/extensions/starlette.py
@@ -29,8 +29,10 @@ class Logout(EndpointHandler):
     async def get(self, request: Request) -> Response:
 
         # request kc logout if we have the needed tokens
-        if "tokens" in request.session and "access_token" in request.session["tokens"] and "refresh_token" in request.session["tokens"]:
-            self.kc.logout(request.session["tokens"]["access_token"], request.session["tokens"]["refresh_token"])
+        if "tokens" in request.session:
+            access_token = request.session["tokens"]["access_token"]
+            refresh_token = request.session["tokens"]["refresh_token"]
+            self.kc.logout(access_token, refresh_token)
             del request.session["tokens"]
 
         if "user" in request.session:
@@ -56,11 +58,11 @@ class Callback(EndpointHandler):
         code = request.query_params["code"]
         tokens = self.kc.callback(code)
 
-        # save the tokens we need for logout in the session
-        # storing too much in default starlette sessions won't let them save properly
+        # starlette session do not have enough capacity to store the entire tokens
+        # so we are saving only access token and refresh token required for performing logout properly
         request.session["tokens"] = {
-            "access_token" : tokens["access_token"],
-            "refresh_token" : tokens["refresh_token"]
+            "access_token" : tokens.access_token,
+            "refresh_token" : tokens.refresh_token
         }
 
         # retrieve user info


### PR DESCRIPTION
Starlette logout wasn't clearing tokens and would log back in - this should fix the problem. This only stores the required parts of the token in session data as starlette seems to clear the session if the full token is stored.

Let me know if there's anything I missed that would prevent this being pulled into main.

Thanks,

Orrin